### PR TITLE
added a better HTML parser

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 beautifulsoup4==4.5.1
 feedgen==0.4.0
 mechanize==0.2.5
+html5lib

--- a/rss-generator.py
+++ b/rss-generator.py
@@ -24,7 +24,7 @@ def google_search(query):
     '''
     urls = []
     response = get_results_page(query)
-    soup = BeautifulSoup(response.read(), 'html.parser')
+    soup = BeautifulSoup(response.read(), 'html5lib')   # using html5lib parser 
     # Search for all relevant 'a' tags
     for a in soup.select('.r a'):
         parsed_url = urlparse.urlparse(a['href'])


### PR DESCRIPTION
Setting html.parser as parser for Beautiful Soup gives following error:
`Traceback (most recent call last):
  File "C:\Users\Sakshi Kathpal\Desktop\rss-generator.py", line 54, in <module>
    main()
  File "C:\Users\Sakshi Kathpal\Desktop\rss-generator.py", line 50, in main
    urls = google_search(query)
  File "C:\Users\Sakshi Kathpal\Desktop\rss-generator.py", line 27, in google_search
    soup = BeautifulSoup(response.read(), 'html.parser')
  File "C:\Python27\lib\site-packages\bs4\__init__.py", line 196, in __init__
    self._feed()
  File "C:\Python27\lib\site-packages\bs4\__init__.py", line 210, in _feed
    self.builder.feed(self.markup)
  File "C:\Python27\lib\site-packages\bs4\builder\_htmlparser.py", line 164, in feed
    raise e
HTMLParseError: junk characters in start tag: u'{t:1}); class="gbzt ', at line 1, column 41946` 

So, I have used another parser (better and advanced) [html5lib](https://pypi.python.org/pypi/html5lib) which works totally fine.
I have also added it to requirements.txt since its a third party library.